### PR TITLE
bam to coverage to pipeline.nf connected

### DIFF
--- a/scripts/nextflow.config
+++ b/scripts/nextflow.config
@@ -19,6 +19,7 @@ params {
   }
   cov = "/vol/pathomg/DB/Plant1DNA1_gt1kb_bt2.bam.coverage.txt,/vol/pathomg/DB/Plant2DNA1_gt1kb_bt2.bam.coverage.txt,/vol/pathomg/DB/Plant3DNA1_gt1kb_bt2.bam.coverage.txt,/vol/pathomg/DB/Plant4DNA1_gt1kb_bt2.bam.coverage.txt"
   out = ""
+  bam = ""
 }
 
 process {


### PR DESCRIPTION
The user can now provide just the bam files without specifing the coverage files with:  


~~~shell
./nextflow pipeline.nf  --bam test1.bam,test2.bam,test3.bam
~~~ 

see #55 